### PR TITLE
Add ability to run schedulers and executors from Python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ default = ["mimalloc"]
 [dependencies]
 async-trait = "0.1"
 ballista = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
+ballista-core = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
+ballista-executor = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
 datafusion = { version = "18.0.0", features = ["pyarrow"] }
 datafusion-common = "18.0.0"
 datafusion-expr = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,11 @@ async-trait = "0.1"
 ballista = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
 ballista-core = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
 ballista-executor = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
+ballista-scheduler = { git = "https://github.com/apache/arrow-ballista", rev = "0.11.0-rc1" }
 datafusion = { version = "18.0.0", features = ["pyarrow"] }
 datafusion-common = "18.0.0"
 datafusion-expr = "18.0.0"
+env_logger = "0.10.0"
 futures = "0.3"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "0.18", features = ["extension-module", "abi3", "abi3-py37"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ datafusion-common = "18.0.0"
 datafusion-expr = "18.0.0"
 env_logger = "0.10.0"
 futures = "0.3"
+log = "0.4.17"
 mimalloc = { version = "*", optional = true, default-features = false }
 pyo3 = { version = "0.18", features = ["extension-module", "abi3", "abi3-py37"] }
 rand = "0.7"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ engine [Ballista](https://github.com/apache/arrow-ballista).
 
 - [Query a Parquet file using SQL](./examples/sql-parquet.py)
 - [Query a Parquet file using DataFrame API](./examples/dataframe-parquet.py)
+- [Start an executor from within a Python process](./examples/run-executor.py)
 
 ## How to install (from pip)
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ engine [Ballista](https://github.com/apache/arrow-ballista).
 
 ### What works?
 
-- Connect to a Ballista scheduler
-- Execute distributed SQL queries
-- Use DataFrame API to read files and execute distributed queries
+- Start Ballista schedulers and executors from Python
+- Execute distributed SQL queries (with DataFusion backend)
+- Use DataFrame API to read files and execute distributed queries (with DataFusion backend)
 - Support for CSV, Parquet, and Avro formats
 
 ### What does not work?
 
 - Python UDFs
+- JSON
 
 ## Roadmap
 
@@ -46,6 +47,7 @@ engine [Ballista](https://github.com/apache/arrow-ballista).
 
 - [Query a Parquet file using SQL](./examples/sql-parquet.py)
 - [Query a Parquet file using DataFrame API](./examples/dataframe-parquet.py)
+- [Start a scheduler from within a Python process](./examples/run-scheduler.py)
 - [Start an executor from within a Python process](./examples/run-executor.py)
 
 ## How to install (from pip)

--- a/ballista/__init__.py
+++ b/ballista/__init__.py
@@ -25,6 +25,7 @@ from ._internal import (
     BallistaContext,
     DataFrame,
     Expression,
+    Executor,
     ScalarUDF,
 )
 
@@ -33,6 +34,7 @@ __all__ = [
     "BallistaContext",
     "DataFrame",
     "Expression",
+    "Executor",
     "AggregateUDF",
     "ScalarUDF",
     "column",

--- a/ballista/__init__.py
+++ b/ballista/__init__.py
@@ -26,6 +26,7 @@ from ._internal import (
     DataFrame,
     Expression,
     Executor,
+    Scheduler,
     ScalarUDF,
 )
 
@@ -35,6 +36,7 @@ __all__ = [
     "DataFrame",
     "Expression",
     "Executor",
+    "Scheduler",
     "AggregateUDF",
     "ScalarUDF",
     "column",

--- a/examples/run-executor.py
+++ b/examples/run-executor.py
@@ -19,9 +19,11 @@ from ballista import Executor
 
 
 # start an executor from this Python process
-exec = Executor(scheduler_host = "localhost",
-                scheduler_port = 50050,
-                bind_host = "127.0.0.1",
-                bind_port = 50051,
-                grpc_port = 50052,
-                concurrent_tasks = 1)
+exec = Executor(
+    scheduler_host="localhost",
+    scheduler_port=50050,
+    bind_host="127.0.0.1",
+    bind_port=50051,
+    grpc_port=50052,
+    concurrent_tasks=1,
+)

--- a/examples/run-executor.py
+++ b/examples/run-executor.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from ballista import Executor
+
+
+# start an executor from this Python process
+exec = Executor(scheduler_host = "localhost",
+                scheduler_port = 50050,
+                bind_host = "127.0.0.1",
+                bind_port = 50051,
+                grpc_port = 50052,
+                concurrent_tasks = 1)

--- a/examples/run-scheduler.py
+++ b/examples/run-scheduler.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from ballista import Scheduler
+
+
+# start a scheduler from this Python process
+scheduler = Scheduler(
+    bind_host="127.0.0.1",
+    bind_port=50050,
+    external_host="127.0.0.1",
+)

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -45,6 +45,8 @@ impl PyExecutor {
         concurrent_tasks: usize,
         py: Python,
     ) -> PyResult<Self> {
+        env_logger::init();
+
         // TODO add option to register a custom query stage executor ExecutionPlan so
         // that we can execute Python plans (delegating to DataFrame libraries)
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ballista_core::config::{LogRotationPolicy, TaskSchedulingPolicy};
+use ballista_executor::executor_process::{ExecutorProcessConfig, start_executor_process};
+use pyo3::prelude::*;
+use crate::errors::BallistaError;
+use crate::utils::wait_for_future;
+
+/// Python wrapper around an executor, allowing users to run an executor within a Python process.
+#[pyclass(name = "Executor", module = "ballista", subclass)]
+pub struct PyExecutor {
+}
+
+#[pymethods]
+impl PyExecutor {
+    #[new]
+    #[pyo3(signature = (
+        scheduler_host,
+        scheduler_port,
+        bind_host,
+        bind_port,
+        grpc_port,
+        concurrent_tasks,
+    ))]
+    fn new(
+        scheduler_host: &str,
+        scheduler_port: u16,
+        bind_host: &str,
+        bind_port: u16,
+        grpc_port: u16,
+        concurrent_tasks: usize,
+        py: Python,
+    ) -> PyResult<Self> {
+
+        // TODO add option to register a custom query stage executor ExecutionPlan so
+        // that we can execute Python plans (delegating to DataFrame libraries)
+
+        let config = ExecutorProcessConfig {
+            special_mod_log_level: "info".to_string(),
+            external_host: None,
+            bind_host: bind_host.to_string(),
+            port: bind_port,
+            grpc_port,
+            scheduler_host: scheduler_host.to_string(),
+            scheduler_port,
+            scheduler_connect_timeout_seconds: 60,
+            concurrent_tasks,
+            task_scheduling_policy: TaskSchedulingPolicy::PullStaged,
+            work_dir: None,
+            log_dir: None,
+            log_file_name_prefix: "".to_string(),
+            log_rotation_policy: LogRotationPolicy::Daily,
+            print_thread_info: true,
+            job_data_ttl_seconds: 60*60,
+            job_data_clean_up_interval_seconds: 60*30,
+        };
+
+        let fut = start_executor_process(config);
+        let _ = wait_for_future(py, fut).map_err(|e| BallistaError::Common(format!("{}", e)))?;
+
+        Ok(Self {  })
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -45,8 +45,6 @@ impl PyExecutor {
         concurrent_tasks: usize,
         py: Python,
     ) -> PyResult<Self> {
-        env_logger::init();
-
         // TODO add option to register a custom query stage executor ExecutionPlan so
         // that we can execute Python plans (delegating to DataFrame libraries)
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -15,16 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ballista_core::config::{LogRotationPolicy, TaskSchedulingPolicy};
-use ballista_executor::executor_process::{ExecutorProcessConfig, start_executor_process};
-use pyo3::prelude::*;
 use crate::errors::BallistaError;
 use crate::utils::wait_for_future;
+use ballista_core::config::{LogRotationPolicy, TaskSchedulingPolicy};
+use ballista_executor::executor_process::{start_executor_process, ExecutorProcessConfig};
+use pyo3::prelude::*;
 
 /// Python wrapper around an executor, allowing users to run an executor within a Python process.
 #[pyclass(name = "Executor", module = "ballista", subclass)]
-pub struct PyExecutor {
-}
+pub struct PyExecutor {}
 
 #[pymethods]
 impl PyExecutor {
@@ -46,7 +45,6 @@ impl PyExecutor {
         concurrent_tasks: usize,
         py: Python,
     ) -> PyResult<Self> {
-
         // TODO add option to register a custom query stage executor ExecutionPlan so
         // that we can execute Python plans (delegating to DataFrame libraries)
 
@@ -66,13 +64,13 @@ impl PyExecutor {
             log_file_name_prefix: "".to_string(),
             log_rotation_policy: LogRotationPolicy::Daily,
             print_thread_info: true,
-            job_data_ttl_seconds: 60*60,
-            job_data_clean_up_interval_seconds: 60*30,
+            job_data_ttl_seconds: 60 * 60,
+            job_data_clean_up_interval_seconds: 60 * 30,
         };
 
         let fut = start_executor_process(config);
         let _ = wait_for_future(py, fut).map_err(|e| BallistaError::Common(format!("{}", e)))?;
 
-        Ok(Self {  })
+        Ok(Self {})
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -342,7 +342,7 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(left))?;
     m.add_wrapped(wrap_pyfunction!(length))?;
     m.add_wrapped(wrap_pyfunction!(ln))?;
-    m.add_wrapped(wrap_pyfunction!(log))?;
+    m.add_wrapped(wrap_pyfunction!(crate::functions::log))?;
     m.add_wrapped(wrap_pyfunction!(log10))?;
     m.add_wrapped(wrap_pyfunction!(log2))?;
     m.add_wrapped(wrap_pyfunction!(lower))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::executor::PyExecutor;
 #[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 use pyo3::prelude::*;
@@ -26,6 +27,8 @@ mod dataframe;
 #[allow(clippy::borrow_deref_ref)]
 mod datatype;
 pub mod errors;
+#[allow(clippy::borrow_deref_ref)]
+mod executor;
 #[allow(clippy::borrow_deref_ref)]
 mod expression;
 #[allow(clippy::borrow_deref_ref)]
@@ -52,6 +55,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<expression::PyExpr>()?;
     m.add_class::<udf::PyScalarUDF>()?;
     m.add_class::<udaf::PyAggregateUDF>()?;
+    m.add_class::<PyExecutor>()?;
 
     // Register the functions as a submodule
     let funcs = PyModule::new(py, "functions")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::executor::PyExecutor;
+use crate::scheduler::PyScheduler;
 #[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 use pyo3::prelude::*;
@@ -33,6 +34,8 @@ mod executor;
 mod expression;
 #[allow(clippy::borrow_deref_ref)]
 mod functions;
+#[allow(clippy::borrow_deref_ref)]
+mod scheduler;
 #[allow(clippy::borrow_deref_ref)]
 mod udaf;
 #[allow(clippy::borrow_deref_ref)]
@@ -56,6 +59,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<udf::PyScalarUDF>()?;
     m.add_class::<udaf::PyAggregateUDF>()?;
     m.add_class::<PyExecutor>()?;
+    m.add_class::<PyScheduler>()?;
 
     // Register the functions as a submodule
     let funcs = PyModule::new(py, "functions")?;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -21,6 +21,7 @@ use ballista_core::config::TaskSchedulingPolicy;
 use ballista_scheduler::cluster::BallistaCluster;
 use ballista_scheduler::config::{ClusterStorageConfig, SchedulerConfig, SlotsPolicy};
 use ballista_scheduler::scheduler_process::start_server;
+use log::info;
 use pyo3::prelude::*;
 
 /// Python wrapper around a scheduler, allowing users to run an scheduler within a Python process.
@@ -37,6 +38,8 @@ impl PyScheduler {
     ))]
     fn new(bind_host: &str, bind_port: u16, external_host: &str, py: Python) -> PyResult<Self> {
         env_logger::init();
+
+        info!("Starting scheduler on {bind_host}:{bind_port}");
 
         let addr = format!("{}:{}", bind_host, bind_port);
         let addr = addr.parse()?;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::errors::BallistaError;
+use crate::utils::wait_for_future;
+use ballista_core::config::TaskSchedulingPolicy;
+use ballista_scheduler::cluster::BallistaCluster;
+use ballista_scheduler::config::{ClusterStorageConfig, SchedulerConfig, SlotsPolicy};
+use ballista_scheduler::scheduler_process::start_server;
+use pyo3::prelude::*;
+
+/// Python wrapper around a scheduler, allowing users to run an scheduler within a Python process.
+#[pyclass(name = "Scheduler", module = "ballista", subclass)]
+pub struct PyScheduler {}
+
+#[pymethods]
+impl PyScheduler {
+    #[new]
+    #[pyo3(signature = (
+    bind_host,
+    bind_port,
+    external_host,
+    ))]
+    fn new(bind_host: &str, bind_port: u16, external_host: &str, py: Python) -> PyResult<Self> {
+        env_logger::init();
+
+        let addr = format!("{}:{}", bind_host, bind_port);
+        let addr = addr.parse()?;
+
+        let config = SchedulerConfig {
+            namespace: "default".to_string(),
+            external_host: external_host.to_string(),
+            bind_port: bind_port,
+            scheduling_policy: TaskSchedulingPolicy::PullStaged,
+            event_loop_buffer_size: 1000,
+            executor_slots_policy: SlotsPolicy::RoundRobin,
+            finished_job_data_clean_up_interval_seconds: 60,
+            finished_job_state_clean_up_interval_seconds: 60,
+            advertise_flight_sql_endpoint: None,
+            cluster_storage: ClusterStorageConfig::Memory,
+            job_resubmit_interval_ms: None,
+        };
+
+        let cluster = BallistaCluster::new_from_config(&config);
+        let cluster =
+            wait_for_future(py, cluster).map_err(|e| BallistaError::Common(format!("{}", e)))?;
+
+        let fut = start_server(cluster, addr, config);
+        wait_for_future(py, fut).map_err(|e| BallistaError::Common(format!("{}", e)))?;
+
+        Ok(Self {})
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -60,7 +60,7 @@ impl PyScheduler {
             wait_for_future(py, cluster).map_err(|e| BallistaError::Common(format!("{}", e)))?;
 
         let fut = start_server(cluster, addr, config);
-        wait_for_future(py, fut).map_err(|e| BallistaError::Common(format!("{}", e)))?;
+        let _ = wait_for_future(py, fut).map_err(|e| BallistaError::Common(format!("{}", e)))?;
 
         Ok(Self {})
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

A small step towards distributed Python execution

## Run Scheduler

```
n$ RUST_LOG=info python ./examples/run-scheduler.py
[2023-02-25T15:43:39Z INFO  ballista_python::scheduler] Starting scheduler on 127.0.0.1:50050
[2023-02-25T15:43:39Z INFO  ballista_scheduler::scheduler_process] Ballista v0.11.0 Scheduler listening on 127.0.0.1:50050
[2023-02-25T15:43:39Z INFO  ballista_scheduler::scheduler_process] Starting Scheduler grpc server with task scheduling policy of PullStaged
[2023-02-25T15:43:39Z INFO  ballista_scheduler::state::executor_manager] Initializing heartbeat listener
[2023-02-25T15:43:39Z INFO  ballista_scheduler::scheduler_server::query_stage_scheduler] Starting QueryStageScheduler
[2023-02-25T15:43:39Z INFO  ballista_core::event_loop] Starting the event loop query_stage
```

## Run Executor

```
$ RUST_LOG=info python ./examples/run-executor.py
2023-02-25T15:45:08.478803Z  INFO ThreadId(01) ballista_executor::executor_process: Running with config:    
2023-02-25T15:45:08.478890Z  INFO ThreadId(01) ballista_executor::executor_process: work_dir: /tmp/.tmpdVTIuq    
2023-02-25T15:45:08.478908Z  INFO ThreadId(01) ballista_executor::executor_process: concurrent_tasks: 1    
2023-02-25T15:45:08.482430Z  INFO ThreadId(01) ballista_executor::executor_process: Connected to scheduler at http://localhost:50050    
2023-02-25T15:45:08.482836Z  INFO tokio-runtime-worker ThreadId(49) ballista_executor::execution_loop: Starting poll work loop with scheduler    
2023-02-25T15:45:08.482849Z  INFO tokio-runtime-worker ThreadId(47) ballista_executor::executor_process: Ballista v0.11.0 Rust Executor Flight Server listening on 127.0.0.1:50051    
2023-02-25T15:45:08.484686Z  INFO tokio-runtime-worker ThreadId(46) ballista_executor::executor_process: The directories [] that have not been modified for 3600 seconds so that they will be deleted    
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- New `PyExecutor` and `PyScheduler` structs
- New examples

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
