### PR TITLE
ci: Harden labeler workflow, remove unnecessary checkout from pull_request_target job

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -29,8 +29,6 @@ jobs:
     name: Process
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
       - name: Assign GitHub labels
         if: |
           github.event_name == 'pull_request_target' &&

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -29,7 +29,6 @@ jobs:
     name: Process
     runs-on: ubuntu-latest
     steps:
-
       - name: Assign GitHub labels
         if: |
           github.event_name == 'pull_request_target' &&

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -29,6 +29,7 @@ jobs:
     name: Process
     runs-on: ubuntu-latest
     steps:
+
       - name: Assign GitHub labels
         if: |
           github.event_name == 'pull_request_target' &&


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR removes the checkout step from the labeler workflow and keeps labeling behavior unchanged.

Tested in https://github.com/apache/datafusion/pull/20637

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
The workflow runs on `pull_request_target`, which has elevated repo context. `actions/labeler` does not require a local checkout to work with `configuration-path`; if the file is not on disk, it fetches it via the GitHub API.

Removing checkout reduces attack surface and avoids exposing persisted git credentials to subsequent steps.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No